### PR TITLE
Set use_sim_time to true as default

### DIFF
--- a/rtabmap_livox/launch/rtabmap_livox.launch.py
+++ b/rtabmap_livox/launch/rtabmap_livox.launch.py
@@ -21,7 +21,7 @@ def generate_launch_description():
 
         # Launch arguments
         DeclareLaunchArgument(
-            'use_sim_time', default_value='false',
+            'use_sim_time', default_value='true',
             description='Use simulation (Gazebo) clock if true'),
         
         DeclareLaunchArgument(


### PR DESCRIPTION
Simulation comes first, and students can get confused to change this parameter as the first step.